### PR TITLE
Fix #106

### DIFF
--- a/static/js/ypet.js
+++ b/static/js/ypet.js
@@ -448,7 +448,9 @@ WordView = Backbone.Marionette.ItemView.extend({
   /* Triggers the proper class assignment
    * when the word <span> is redrawn */
   onRender : function() {
-    this.$el.css({'margin-right': this.model.get('neighbor') ? '5px' : '0px'});
+    this.$el.css(this.model.get('neighbor') ?
+      {'margin-right': '5px', 'padding-right': '0'} :
+      {'margin-right': '0px', 'padding-right': '5px'});
   },
 
   /* When clicking down, make sure to keep track

--- a/static/scss/utils/_document.scss
+++ b/static/scss/utils/_document.scss
@@ -12,6 +12,12 @@ p.paragraph {
   -webkit-touch-callout: none;
   @include user-select(none);
 
+  span {
+    display: inline-block;
+    padding-right: 5px;
+    line-height: 1em;
+  }
+
   span:hover {
     color: $color_picton_blue;
   }


### PR DESCRIPTION
This fixed #106 when the last word of each line gets bumped into the next line. I have personally tested it on my machine and no more display issue was discovered. 

The changes listed only involve css changes, meaning nothing is modified in the bahavior of ypet:

- The CSS of each span is modified in `_document.scss`
- The behavior of [onRender](https://github.com/SuLab/mark2cure/blob/master/static/js/ypet.js#L450) in `ypet.js` is also modifed to fix the display of a single word caused by modifying `_document.scss`